### PR TITLE
Add map geolocation and camera shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,21 @@
     .favorite .fav { display: block; }
     .land-header.badge-earned::after { content: '⭐'; margin-left: 0.25rem; }
     #party-code { width: 100%; min-height: 100px; padding: 0.5rem; border-radius: 8px; border: 1px solid var(--glass-border); background: var(--glass-bg); color: var(--text-primary); }
+    .camera-btn {
+      background: var(--glass-bg);
+      border: 1px solid var(--glass-border);
+      border-radius: 12px;
+      padding: 0.6rem 1.2rem;
+      color: var(--text-primary);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+      margin-bottom: 1rem;
+    }
+    .camera-btn:hover { transform: translateY(-2px); }
+    #map-container { width:100%; height:60vh; max-height:400px; border-radius:12px; overflow:hidden; }
+    #map-container iframe { width:100%; height:100%; border:0; }
   </style>
 </head>
 <body>
@@ -311,6 +326,10 @@
         <button class="menu-btn" onclick="openPhotos()">
           <span class="emoji">📸</span>
           <span>Photo Hunts</span>
+        </button>
+        <button class="menu-btn" onclick="openMap()">
+          <span class="emoji">🗺️</span>
+          <span>Park Map</span>
         </button>
         <button class="menu-btn" onclick="openParty()">
           <span class="emoji">🎉</span>
@@ -467,7 +486,16 @@
     <div id="photo-page" class="page">
       <button class="back-btn" onclick="goHome()">← Back to Parks</button>
       <div class="park-title">📸 Photo Hunts</div>
+      <button class="camera-btn" onclick="launchCamera()">📷 Take Photo</button>
+      <input type="file" id="camera-input" accept="image/*" capture="environment" style="display:none;">
       <div class="secrets-grid" id="photo-list"></div>
+    </div>
+    <!-- PARK MAP -->
+    <div id="map-page" class="page">
+      <button class="back-btn" onclick="goHome()">← Back to Parks</button>
+      <div class="park-title">🗺️ Park Map</div>
+      <p>Grant location access to see where you are in the park.</p>
+      <div id="map-container"><iframe id="map-frame" allowfullscreen></iframe></div>
     </div>
     <!-- PARTY MODE -->
     <div id="party-page" class="page">
@@ -540,6 +568,32 @@
       document.getElementById('photo-page').classList.add('active');
       renderHunts();
       window.scrollTo(0, 0);
+    }
+    function openMap() {
+      document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+      document.getElementById('map-page').classList.add('active');
+      updateMapLocation();
+      window.scrollTo(0, 0);
+    }
+    function updateMapLocation() {
+      const frame = document.getElementById('map-frame');
+      if (!frame) return;
+      if (!navigator.geolocation) {
+        frame.src = 'https://www.openstreetmap.org';
+        return;
+      }
+      navigator.geolocation.getCurrentPosition(pos => {
+        const lat = pos.coords.latitude;
+        const lon = pos.coords.longitude;
+        const bbox = `${lon-0.005},${lat-0.005},${lon+0.005},${lat+0.005}`;
+        frame.src = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${lat},${lon}`;
+      }, () => {
+        frame.src = 'https://www.openstreetmap.org';
+      });
+    }
+    function launchCamera() {
+      const input = document.getElementById('camera-input');
+      if (input) input.click();
     }
     function openParty() {
       document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));


### PR DESCRIPTION
## Summary
- include a quick camera button on the Photo Hunts page
- add a park map page that uses geolocation to show the user's position
- support new navigation functions and styles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_685fc405dcb8833092732a3295ec5739