### PR TITLE
Fix camera scanning to open party link

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,8 +639,13 @@
           const result = window.jsQR && jsQR(imageData.data, canvas.width, canvas.height);
           if (result) {
             stopQRScan();
-            document.getElementById('party-code').value = result.data;
-            importProgress();
+            const text = result.data.trim();
+            document.getElementById('party-code').value = text;
+            if (/^https?:\/\//i.test(text)) {
+              window.location.href = text;
+            } else {
+              importProgress();
+            }
             return;
           }
         }


### PR DESCRIPTION
## Summary
- open scanned QR links automatically during Party Mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685fc9ac469083308525b890f9541db1