### PR TITLE
Add Disney tips and update snacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -836,21 +836,36 @@
         {emoji:"🗝️", name:"Ask about the 'Keys to the Kingdom' tour", desc:"Only for superfans"},
         {emoji:"🦴", name:"Look for the talking trash can (Push!)", desc:"Tomorrowland (sometimes appears)"},
         {emoji:"🐶", name:"Spot the 'Smiling Dog' in Pirates of the Caribbean", desc:"The one with keys in his mouth!"}
+        {emoji:"🦎", name:"Count the hidden Pascals near the Tangled restrooms", desc:"See how many you can spot"},
+        {emoji:"🏞️", name:"Snap a moody photo in the Tangled restrooms at dusk", desc:"Lanterns glow beautifully"},
+        {emoji:"🌉", name:"Watch Happily Ever After fireworks from the Tomorrowland bridge", desc:"Less crowded, great view"},
+        {emoji:"🚢", name:"Catch the Liberty Belle Riverboat at sunset", desc:"Unique castle perspectives"},
+        {emoji:"🗝️", name:"Spot hidden Mickeys around the park", desc:"Challenge: find at least three"},
+        {emoji:"🚇", name:"Ride the PeopleMover at night", desc:"Neon views of Tomorrowland"},
+        {emoji:"🎡", name:"Ride Big Thunder Mountain during fireworks", desc:"Epic nighttime views"},
+        {emoji:"🎢", name:"Sit front row on Space Mountain", desc:"Most intense ride experience"},
+        {emoji:"🦇", name:"Selfie with the bat details in Haunted Mansion queue", desc:"Spooky queue decor"},
+        {emoji:"🚂", name:"Ride the train around the park", desc:"Relax and people-watch"},
       ],
       EPCOT: [
         {emoji:"🥤", name:"Try every soda at Club Cool (even Beverly)", desc:"Near Creations Shop"},
-        {emoji:"🚇", name:"Snap a photo at the Bubblegum Wall", desc:"Exit of Spaceship Earth"},
+        {emoji:"🎨", name:"Look for the Bubblegum & Blueberry Walls", desc:"Colorful photo spots outside Spaceship Earth"},
         {emoji:"🚃", name:"Find a hidden Mickey in Germany's train garden", desc:"World Showcase"},
         {emoji:"⛲", name:"Notice the 'burning Rome' scent in Spaceship Earth", desc:"During the fire scene"},
         {emoji:"🌸", name:"Explore Morocco’s quiet back alleys", desc:"So many details!"},
         {emoji:"🎤", name:"Enjoy Voices of Liberty a cappella", desc:"American Adventure rotunda"},
-        {emoji:"🎡", name:"See night lights on Spaceship Earth", desc:"'Beacons of Magic' show"},
+        {emoji:"🌌", name:"Watch the projections on Spaceship Earth after dark", desc:"Beacons of Magic show"},
         {emoji:"🍧", name:"Eat School Bread in Norway", desc:"Bakery in Norway pavilion"},
         {emoji:"🍦", name:"Try a macaron ice cream sandwich", desc:"France pavilion"},
         {emoji:"🔎", name:"Spot a hidden Mickey in Living with the Land", desc:"Greenhouse scenes"},
         {emoji:"🥚", name:"Try a festival scavenger hunt", desc:"Like Remy’s or Figment’s!"},
         {emoji:"🗼", name:"Notice the bird-free Eiffel Tower", desc:"Painted with special paint"},
         {emoji:"🎩", name:"Find Dreamfinder references at Imagination Pavilion", desc:"Classic EPCOT fans only!"}
+        {emoji:"🚅", name:"Design a wild car at Test Track to beat your friends", desc:"Compare scores"},
+        {emoji:"🏯", name:"Take a forced-perspective photo with Spaceship Earth \"in your hand\"", desc:"Line up from afar"},
+        {emoji:"🎠", name:"Ride Living with the Land at sunset or in rain", desc:"Relaxing views"},
+        {emoji:"🚄", name:"Ride the Skyliner for sunset photos", desc:"Great aerial angles"},
+        {emoji:"🎼", name:"Listen for hidden musical cues at each pavilion entrance", desc:"Subtle details"}
       ],
       HS: [
         {emoji:"☂️", name:"Stand under the Singing in the Rain umbrella", desc:"Pull the handle near Echo Lake"},
@@ -863,6 +878,7 @@
         {emoji:"💼", name:"Find Walt’s office window", desc:"Look for his name in the windows"},
         {emoji:"🥓", name:"Eat Totchos at Woody’s Lunch Box", desc:"Potato barrel + chili cheese"},
         {emoji:"🍪", name:"Get a Jack-Jack’s Num Num Cookie", desc:"Super gooey, Pixar Place"}
+        {emoji:"🧳", name:"Look for clever fake hotel guest names in the Tower of Terror guest book", desc:"Check the lobby desk"},
       ],
       AK: [
         {emoji:"🦖", name:"Take a selfie with Dino Sue", desc:"Near DINOSAUR entrance"},
@@ -876,6 +892,7 @@
         {emoji:"🦘", name:"Watch kangaroos by Tree of Life", desc:"Morning is best"},
         {emoji:"⛰️", name:"Spot the Yeti Shrine at Everest", desc:"Near the ride entrance"},
         {emoji:"🦕", name:"Listen for dinosaur sounds outside DINOSAUR", desc:"Hidden speakers!"}
+        {emoji:"🦉", name:"Explore the hidden trails behind the Tree of Life", desc:"Quiet photo spots with no crowds"},
       ],
       USF: [
         {emoji:"🐍", name:"See Kreacher peek from 12 Grimmauld Place", desc:"Knock, watch the window"},
@@ -909,10 +926,10 @@
     };
     const foods = {
       MK: [
-        {emoji:"🍍", name:"Dole Whip", desc:"Aloha Isle (Adventureland)", type:"sweet"},
+        {emoji:"🍍", name:"Dole Whip swirl", desc:"Aloha Isle – enjoy on the Tiki Room patio", type:"sweet"},
         {emoji:"🥐", name:"Cheshire Cat Tail", desc:"Cheshire Café (Fantasyland)", type:"sweet"},
         {emoji:"🥨", name:"Mickey Pretzel", desc:"Snack Carts", type:"savory"},
-        {emoji:"🥟", name:"Spring Rolls", desc:"Adventureland cart", type:"savory"},
+        {emoji:"🥟", name:"Cheeseburger Spring Rolls", desc:"Adventureland cart", type:"savory"},
         {emoji:"🌭", name:"Corn Dog Nuggets", desc:"Casey’s Corner", type:"savory"},
         {emoji:"🍎", name:"LeFou’s Brew", desc:"Gaston’s Tavern", type:"drink"}
       ],
@@ -926,7 +943,7 @@
       ],
       HS: [
         {emoji:"🌯", name:"Ronto Wrap", desc:"Ronto Roasters", type:"savory"},
-        {emoji:"🍪", name:"Num Num Cookie", desc:"Pixar Place Market", type:"sweet"},
+        {emoji:"🍪", name:"Jack Jack Num Num Cookie", desc:"Pixar Place Market - great to share", type:"sweet"},
         {emoji:"🥔", name:"Totchos", desc:"Woody’s Lunch Box", type:"savory"},
         {emoji:"🥛", name:"Blue/Green Milk", desc:"Milk Stand", type:"drink"},
         {emoji:"🥕", name:"Carrot Cake Cookie", desc:"Trolley Car Café", type:"sweet"}


### PR DESCRIPTION
## Summary
- add more hidden secrets for Magic Kingdom, EPCOT, Hollywood Studios and Animal Kingdom
- tweak existing Epcot photo spot info and night projections tip
- update Magic Kingdom food items and Hollywood Studios cookie name

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_685fef2ae3a483308253eaee79888b2c