### PR TITLE
Fix photo hunt and reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -684,6 +684,10 @@
       });
     }
     function launchCamera() {
+      if (!currentHuntKey) {
+        alert('Tap a hunt below first to attach your photo.');
+        return;
+      }
       const input = document.getElementById('camera-input');
       if (input) input.click();
     }
@@ -1564,6 +1568,7 @@
       localStorage.removeItem('hiddenParkFoodFav');
       localStorage.removeItem('parkAchievements');
       localStorage.removeItem('photoHunts');
+      localStorage.removeItem('dayPlan');
       localStorage.removeItem("seenCharlieWelcome");
       location.reload();
     }


### PR DESCRIPTION
## Summary
- ensure a hunt card is selected before opening the camera
- clear saved day planner data on reset

## Testing
- `tidy -qe index.html` *(fails: `tidy` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ff3bff3f08330b5d46417339bf16b