### PR TITLE
Add Bluetooth beacon check-in support

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,10 @@
           <span class="emoji">📷</span>
           <span>Camera</span>
         </button>
+        <button class="menu-btn" onclick="openBeaconPage()">
+          <span class="emoji">📶</span>
+          <span>Beacon Check-Ins</span>
+        </button>
       </div>
       
       <button class="reset-btn" onclick="resetProgress()">🔄 Reset All Progress</button>
@@ -572,6 +576,14 @@
       </div>
     </div>
   </div>
+  <!-- BEACON CHECK-INS -->
+  <div id="beacon-page" class="page">
+    <button class="back-btn" onclick="goHome()">← Back to Parks</button>
+    <div class="park-title">📶 Beacon Check-Ins</div>
+    <p>Scan for Bluetooth beacons to mark rides complete.</p>
+    <button class="camera-btn" onclick="startBeaconScan()">🔍 Start Scanning</button>
+    <div class="secrets-grid" id="beacon-list"></div>
+  </div>
   <!-- PARTY MODE -->
   <div id="party-page" class="page">
       <button class="back-btn" onclick="goHome()">← Back to Parks</button>
@@ -805,6 +817,11 @@
         startARCamera();
       }
     }
+    function openBeaconPage() {
+      stopBeaconScan();
+      showPage('beacon-page');
+      renderBeacons();
+    }
     function openQuest() {
       showPage('quest-page');
       renderQuestLog();
@@ -815,6 +832,7 @@
     function goHome() {
       stopQRScan();
       stopARCamera();
+      stopBeaconScan();
       showPage('main-menu');
     }
     // Modal functions
@@ -1182,6 +1200,11 @@
         secrets[p].map(h => ({ emoji: h.emoji, desc: h.name }))
       )
     ];
+    const beaconCheckpoints = [
+      {id:'tron', emoji:'🏍️', name:'TRON Lightcycle', device:'TronBeacon', ride:'MK-ride-tomorrow-0'},
+      {id:'haunt', emoji:'👻', name:'Haunted Mansion', device:'HauntBeacon', ride:'MK-ride-liberty-0'}
+    ];
+    const beaconStatus = JSON.parse(localStorage.getItem('beaconStatus') || '{}');
     // Render secrets (Cool Hidden Stuff)
     parkList.forEach(park => {
       const grid = document.getElementById(park + "-secrets");
@@ -1518,6 +1541,55 @@
       checkBadge(grid);
     }
 
+    function renderBeacons() {
+      const grid = document.getElementById('beacon-list');
+      if (!grid) return;
+      grid.innerHTML = '';
+      beaconCheckpoints.forEach(b => {
+        const card = document.createElement('div');
+        card.className = 'secret-card glass-card' + (beaconStatus[b.id] ? ' done' : '');
+        card.innerHTML = `<div class="card-content"><span class="card-emoji">${b.emoji}</span><div class="card-info"><div class="card-name">${b.name}</div></div><span class="tick">✔️</span></div>`;
+        grid.appendChild(card);
+      });
+      checkBadge(grid);
+    }
+
+    let beaconScan = null;
+    function startBeaconScan() {
+      if (!navigator.bluetooth || !navigator.bluetooth.requestLEScan) {
+        alert('Bluetooth scanning not supported.');
+        return;
+      }
+      if (beaconScan) return;
+      navigator.bluetooth.requestLEScan({ acceptAllAdvertisements: true })
+        .then(scan => {
+          beaconScan = scan;
+          navigator.bluetooth.addEventListener('advertisementreceived', handleBeacon);
+        })
+        .catch(() => alert('Scan failed or permission denied.'));
+    }
+    function handleBeacon(event) {
+      const name = event.device.name;
+      const b = beaconCheckpoints.find(x => x.device === name);
+      if (b && !beaconStatus[b.id]) {
+        beaconStatus[b.id] = true;
+        localStorage.setItem('beaconStatus', JSON.stringify(beaconStatus));
+        if (b.ride) {
+          saved[b.ride] = true;
+          localStorage.setItem('hiddenParkFullScreenCharlieRides', JSON.stringify(saved));
+        }
+        renderBeacons();
+        showBadge('Checked in: ' + b.name);
+      }
+    }
+    function stopBeaconScan() {
+      if (beaconScan) {
+        beaconScan.stop();
+        beaconScan = null;
+        navigator.bluetooth.removeEventListener('advertisementreceived', handleBeacon);
+      }
+    }
+
     let currentHuntKey = null;
     let currentHuntCard = null;
     function captureHuntPhoto(key, card) {
@@ -1624,6 +1696,7 @@
       localStorage.removeItem('parkAchievements');
       localStorage.removeItem('photoHunts');
       localStorage.removeItem('questLog');
+      localStorage.removeItem('beaconStatus');
       localStorage.removeItem('dayPlan');
       localStorage.removeItem("seenCharlieWelcome");
       location.reload();


### PR DESCRIPTION
## Summary
- add Beacon Check-Ins button to the main menu
- implement Beacon Check-Ins page with scanning option
- add beacon definitions and scanning logic using Web Bluetooth
- auto mark rides complete when beacons are found
- stop scanning when leaving beacon page
- clear beacon progress on reset

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6860658354b08330a071fb2410ef8342