### PR TITLE
Fix PWA assets without binary icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Dobbies Guide">
-  <link rel="apple-touch-icon" href="icon.png">
   <link rel="manifest" href="manifest.json">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
   <style>
@@ -1704,6 +1703,11 @@
   </script>
   <script src="qrcode.min.js"></script>
   <script src="jsQR.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+  </script>
 </body>
 </html>
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,12 +4,5 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#1a1a2e",
-  "background_color": "#1a1a2e",
-  "icons": [
-    {
-      "src": "icon.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    }
-  ]
+  "background_color": "#1a1a2e"
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,30 @@
+const CACHE_NAME = 'parkguide-cache-v1';
+const ASSETS = [
+  './',
+  'index.html',
+  'jsQR.js',
+  'qrcode.min.js',
+  'cube.glb',
+  'cube.usdz',
+  'manifest.json',
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.map(k => (k !== CACHE_NAME ? caches.delete(k) : null)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- remove previously added `icon.png`
- drop apple-touch-icon link from HTML
- prune icons entry from manifest
- update service worker asset list

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6860680faee88330a94b5d6f1c345b14